### PR TITLE
feat: persist target and last command

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,10 +19,20 @@
 
 ## Persistence
 
-- [-] optionally save last selected target to disk and reload on startup
+- [x] optionally save last selected target to disk and reload on startup
+- [ ] save last command
+    - this may have to happen on nvim close since we don't want to rewrite that settings file
+      each time the user executes a command (unless we ensure to do this only if the command
+      changed)
+
+### Won't do
+
 - [ ] save command history to disk and reload via command or automatically if so configured
   - there should be two types of histories, one per project and one where we show all commands
     from all projects
+
+`:Telescope command_history` fuzzy searched for `TmuxCommand` provides that functionality and
+more.
 
 It would be very nice to have multiple setups since they depend on the project.
 Either we key them by the full path to the root of the current vim session or allow users to

--- a/TODO.md
+++ b/TODO.md
@@ -15,39 +15,19 @@
       loosing it
 - [x] falling back to pane at same index as target pane should it have been destroyed
       (configurable)
-- [ ] KillRunnerPane (low priority)
 
 ## Persistence
 
 - [x] optionally save last selected target to disk and reload on startup
-- [ ] save last command
+- [-] save last command
     - this may have to happen on nvim close since we don't want to rewrite that settings file
       each time the user executes a command (unless we ensure to do this only if the command
       changed)
-
-### Won't do
-
-- [ ] save command history to disk and reload via command or automatically if so configured
-  - there should be two types of histories, one per project and one where we show all commands
-    from all projects
-
-`:Telescope command_history` fuzzy searched for `TmuxCommand` provides that functionality and
-more.
-
-It would be very nice to have multiple setups since they depend on the project.
-Either we key them by the full path to the root of the current vim session or allow users to
-label them. (similar to [startify](https://github.com/mhinz/vim-startify)).
-The code startify uses to save the sessions [in
-viml](https://github.com/mhinz/vim-startify/blob/master/autoload/startify.vim#L215)
-
-We could also save the target info inside a `.tmuxrun.json` file or similar in the current vim
-root and look for it at startup (configurable) or only when `TmuxLoadTarget` is called.
 
 ## Runner
 
 - [x] repeat last command
 - [x] bring window to front when sending keys (if its's in the background) configurable
-- [ ] store command history and allow selecting one 
 - [x] clear sequence doesn't really work, prefixing with `clear;` does
 - [ ] save (current file | all files) before running command configurable
 - [x] resolve things like `%` (to current path) configurable
@@ -57,12 +37,22 @@ root and look for it at startup (configurable) or only when `TmuxLoadTarget` is 
 - [x] SendUp (repeats whatever was executed last in the pane)
   - this is very useful when a command was executed in the pane already and we just want to
     repeat it without copy/pasting it and send via `TmuxCommand`
-- [ ] integrate command history with telescope
 - [x] should not protect vim pane if we selected another session
   - which means that we want to be able to select a pane with the same number as our vim pane
     when it is in a different session and/or window
   - right now if we have vim open in pane one that pane is blocked in all sessions and windows
 
-## Tmux
+## Maybe Later
 
 - [ ] FocusRunnerPane and optionally zoom it (might not be possible across sessions)
+- [ ] KillRunnerPane
+
+## Won't do
+
+- [ ] save command history to disk and reload via command or automatically if so configured
+  - there should be two types of histories, one per project and one where we show all commands
+    from all projects
+  - [ ] integrate command history with telescope
+
+`:Telescope command_history` fuzzy searched for `TmuxCommand` provides that functionality and
+more.

--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,7 @@
 ## Persistence
 
 - [x] optionally save last selected target to disk and reload on startup
-- [-] save last command
+- [x] save last command
     - this may have to happen on nvim close since we don't want to rewrite that settings file
       each time the user executes a command (unless we ensure to do this only if the command
       changed)
@@ -29,9 +29,9 @@
 - [x] repeat last command
 - [x] bring window to front when sending keys (if its's in the background) configurable
 - [x] clear sequence doesn't really work, prefixing with `clear;` does
-- [ ] save (current file | all files) before running command configurable
 - [x] resolve things like `%` (to current path) configurable
   - only supports replacing one occurrence which should cover 90% of cases
+- [ ] save (current file | all files) before running command configurable
 - [ ] SendCtrlD
 - [ ] SendCtrlC
 - [x] SendUp (repeats whatever was executed last in the pane)

--- a/lua/tmuxrun/api.lua
+++ b/lua/tmuxrun/api.lua
@@ -18,7 +18,14 @@ local function handleCommand(cmd, opts)
 	end
 	runner:sendKeys(cmd, opts)
 	if opts.storeCommand then
-		state.lastCommand = cmd
+		if cmd ~= state.lastCommand then
+			state.lastCommand = cmd
+			-- saving settings only if command changed which should be fine since we expect
+			-- the same commmand to be repeated much more in which case we don't persist
+			if conf.persistCommand then
+				api.saveSettings()
+			end
+		end
 	end
 end
 
@@ -90,12 +97,15 @@ end
 -- for instance whenever a new target is selected.
 -- However if a user wants to call this then they can.
 function api.saveSettings()
-	local savedSettings = persistence.save()
+	persistence.save(state)
 end
 
 -- This isn't exposed either as it is invoked as part of tmuxrun.setup (see ./init.lua)
 function api.loadSettings()
 	local loadedSettings = persistence.load()
+	if conf.persistCommand and loadedSettings.lastCommand ~= nil then
+		state.lastCommand = loadedSettings.lastCommand
+	end
 end
 
 return api

--- a/lua/tmuxrun/config.lua
+++ b/lua/tmuxrun/config.lua
@@ -27,6 +27,7 @@ local values = {
 	fallbackToPaneIndex = true,
 
 	-- if true the selected targets are persisted to disk for each project
+	-- whenever a settings item like the target changes
 	-- the root folder of a vim session is used to identify projects
 	persistTarget = true,
 
@@ -56,6 +57,7 @@ function config.setup(opts)
 	config.setValue("ensureTarget", opts.ensureTarget, true)
 	config.setValue("storeUpCommand", opts.storeUpCommand, true)
 	config.setValue("fallbackToPaneIndex", opts.fallbackToPaneIndex, true)
+	config.setValue("persistTarget", opts.persistTarget, true)
 	config.setValue("gitProjects", opts.gitProjects, true)
 end
 

--- a/lua/tmuxrun/config.lua
+++ b/lua/tmuxrun/config.lua
@@ -4,20 +4,27 @@
 local values = {
 	-- clear terminal pane before sending the command keys
 	clearBeforeSend = true,
+
 	-- clear sequence to use for the above
 	clearSequence = "",
+
 	-- in which direction to create a pane when tmuxrun creates it automatically
 	-- change to '{ placement = "after", direction = "horizontal" }' to split horizontally
 	autoSplitPane = { placement = "after", direction = "vertical" },
+
 	-- time in milliseconds give new terminal pane to get ready to receive commands
 	newPaneInitTime = 0,
+
 	-- ensures that the window that a command is sent to comes into view
 	activateTargetWindow = true,
+
 	-- ensures target when sending a command unless it is overriden for the particular call
 	ensureTarget = true,
+
 	-- Stores 'Up' sent via :TmuxUp as lastCommand such that :TmuxRepeatCommand will send 'Up'.
 	-- Set this to false if you only want to store only commands sent via :TmuxCommand
 	storeUpCommand = true,
+
 	-- If a pane cannot be found by id, i.e. if it was closed, then tmuxrun will
 	-- try to find a pane that is at the index where the one it cannot find was
 	-- when it was selected as a target. That pane will be used going forward
@@ -31,8 +38,12 @@ local values = {
 	-- the root folder of a vim session is used to identify projects
 	persistTarget = true,
 
+	-- if true then each time a new command is executed it is persisted and loaded
+	-- at startup
+	persistCommand = true,
+
 	-- if true a `.git` folder when found is considered to define a project for which settings are saved
-	-- if false the current working dir `pwd` is defines that project
+	-- if false the current working dir `pwd` defines that project instead
 	gitProjects = true,
 }
 
@@ -58,6 +69,7 @@ function config.setup(opts)
 	config.setValue("storeUpCommand", opts.storeUpCommand, true)
 	config.setValue("fallbackToPaneIndex", opts.fallbackToPaneIndex, true)
 	config.setValue("persistTarget", opts.persistTarget, true)
+	config.setValue("persistCommand", opts.persistCommand, true)
 	config.setValue("gitProjects", opts.gitProjects, true)
 end
 

--- a/lua/tmuxrun/config.lua
+++ b/lua/tmuxrun/config.lua
@@ -25,6 +25,14 @@ local values = {
 	-- next one at its index will be promoted and so on.
 	-- Set this to false to turn off that behavior.
 	fallbackToPaneIndex = true,
+
+	-- if true the selected targets are persisted to disk for each project
+	-- the root folder of a vim session is used to identify projects
+	persistTarget = true,
+
+	-- if true a `.git` folder when found is considered to define a project for which settings are saved
+	-- if false the current working dir `pwd` is defines that project
+	gitProjects = true,
 }
 
 local config = { values = values }
@@ -48,6 +56,7 @@ function config.setup(opts)
 	config.setValue("ensureTarget", opts.ensureTarget, true)
 	config.setValue("storeUpCommand", opts.storeUpCommand, true)
 	config.setValue("fallbackToPaneIndex", opts.fallbackToPaneIndex, true)
+	config.setValue("gitProjects", opts.gitProjects, true)
 end
 
 return config

--- a/lua/tmuxrun/init.lua
+++ b/lua/tmuxrun/init.lua
@@ -1,9 +1,11 @@
+local persistence = require("tmuxrun.persistence")
 local config = require("tmuxrun.config")
 
 local M = {}
 
 function M.setup(opts)
 	config.setup(opts)
+	persistence.load()
 	return M
 end
 

--- a/lua/tmuxrun/init.lua
+++ b/lua/tmuxrun/init.lua
@@ -1,11 +1,11 @@
-local persistence = require("tmuxrun.persistence")
+local api = require("tmuxrun.api")
 local config = require("tmuxrun.config")
 
 local M = {}
 
 function M.setup(opts)
 	config.setup(opts)
-	persistence.load()
+	api.loadSettings()
 	return M
 end
 

--- a/lua/tmuxrun/persistence.lua
+++ b/lua/tmuxrun/persistence.lua
@@ -14,12 +14,23 @@ local config = import("tmuxrun.config")
 local conf = config.values
 
 -- -----------------
+-- Get Storage Path
+-- -----------------
+local function getDataDir()
+	if vim.fn.has("nvim-0.3.1") == 1 then
+		return vim.fn.stdpath("data")
+	elseif vim.fn.has("win32") == 1 then
+		return "~/AppData/Local/nvim-data/"
+	else
+		return "~/.local/share/nvim"
+	end
+end
+
+local settingsFile = getDataDir() .. "/tmuxrun.json"
+
+-- -----------------
 -- Load/Save Settings
 -- -----------------
-
--- TODO(thlorenz): figure out where to put that
-local settingsFile = "/tmp/tmuxrun.json"
-
 local function getSettingsKey()
 	if conf.gitProjects then
 		-- try nearest git dir first since that is more likely to denote a project root
@@ -62,6 +73,8 @@ local function saveSettings(settings)
 	local f = io.open(settingsFile, "w")
 	f:write(json)
 	f:close()
+
+	return settings
 end
 
 -- -----------------
@@ -88,12 +101,11 @@ end
 -- -----------------
 -- API
 -- -----------------
-
 function M.save()
 	local encodedTarget = encodeTarget()
 	local settings = encodedTarget ~= nil and { target = encodedTarget } or {}
 
-	saveSettings(settings)
+	return saveSettings(settings)
 end
 
 function M.load()
@@ -101,10 +113,11 @@ function M.load()
 	if settings.target ~= nil then
 		restoreTarget(settings.target)
 	end
+	return settings
 end
 
 if utils.isMain() then
-	M.load()
+	print(settingsFile)
 end
 
 return M

--- a/lua/tmuxrun/persistence.lua
+++ b/lua/tmuxrun/persistence.lua
@@ -9,27 +9,33 @@ else
 	import = require
 end
 
-local sessions = import("tmuxrun.sessions")
 local selector = import("tmuxrun.selector")
 
-function M.store(self, sessionId, windowId, paneId) end
+function M.store()
+	-- TODO(thlorenz): use the below to store
+	if
+		selector.session == nil
+		or selector.window == nil
+		or selector.pane == nil
+	then
+		return
+	end
 
-function M.restore(sessionId, windowId, paneId)
-	assert(sessionId ~= nil, "need sessionId to restore")
-	assert(windowId ~= nil, "need windowId to restore")
-	assert(paneId ~= nil, "need paneId to restore")
+	local encodedTarget = selector:encodeTarget()
+	print(encodedTarget)
+	return encodedTarget
+end
 
-	selector:restoreTargetFromIds(sessionId, windowId, paneId)
+function M.restore(encodedTarget)
+	assert(encodedTarget ~= nil, "need encoded session target to restore")
+
+	selector:restoreFromEncodedTarget(encodedTarget)
+	vim.pretty_print(selector.pane)
 end
 
 if utils.isMain() then
-	local sessionId = "$9"
-	local windowId = "@58"
-	local paneId = "%75"
-	M.restore(sessionId, windowId, paneId)
-
-	vim.pretty_print(selector.window)
-	vim.pretty_print(selector.pane)
+	local encodedTarget = "$9" .. "&" .. "@58" .. "&" .. "%75"
+	M.restore(encodedTarget)
 end
 
 return M

--- a/lua/tmuxrun/persistence.lua
+++ b/lua/tmuxrun/persistence.lua
@@ -1,0 +1,35 @@
+local M = {}
+
+local utils = require("tmuxrun.utils")
+
+local import
+if utils.isMain() then
+	import = utils.re_require
+else
+	import = require
+end
+
+local sessions = import("tmuxrun.sessions")
+local selector = import("tmuxrun.selector")
+
+function M.store(self, sessionId, windowId, paneId) end
+
+function M.restore(sessionId, windowId, paneId)
+	assert(sessionId ~= nil, "need sessionId to restore")
+	assert(windowId ~= nil, "need windowId to restore")
+	assert(paneId ~= nil, "need paneId to restore")
+
+	selector:restoreTargetFromIds(sessionId, windowId, paneId)
+end
+
+if utils.isMain() then
+	local sessionId = "$9"
+	local windowId = "@58"
+	local paneId = "%75"
+	M.restore(sessionId, windowId, paneId)
+
+	vim.pretty_print(selector.window)
+	vim.pretty_print(selector.pane)
+end
+
+return M

--- a/lua/tmuxrun/selector.lua
+++ b/lua/tmuxrun/selector.lua
@@ -10,6 +10,8 @@ local M = {
 	pane = nil,
 }
 
+local SEP = "&"
+
 local utils = require("tmuxrun.utils")
 local sessions = require("tmuxrun.sessions")
 local tmux = require("tmuxrun.tmux")
@@ -315,6 +317,26 @@ function M.restoreTargetFromIds(self, sessionId, windowId, paneId)
 		self.window = window
 		self.pane = pane
 	end
+end
+
+function M.restoreFromEncodedTarget(self, encodedTarget)
+	local sessionId, windowId, paneId = utils.split(
+		"^(.+)" .. SEP .. "(.+)" .. SEP .. "(.+)",
+		utils.trim(encodedTarget)
+	)
+	if sessionId == nil or windowId == nil or paneId == nil then
+		return
+	end
+
+	self:restoreTargetFromIds(sessionId, windowId, paneId)
+end
+
+function M.encodeTarget(self)
+	if self.session == nil or self.window == nil or self.pane == nil then
+		return
+	end
+
+	return self.session.id .. SEP .. self.window.id .. SEP .. self.pane.id
 end
 
 -- -----------------

--- a/lua/tmuxrun/selector.lua
+++ b/lua/tmuxrun/selector.lua
@@ -297,10 +297,33 @@ function M.activateCurrentWindow(self)
 end
 
 -- -----------------
+-- Persistence
+-- -----------------
+function M.restoreTargetFromIds(self, sessionId, windowId, paneId)
+	sessions:refresh()
+
+	local session, window, pane = sessions:getSessionWindowPaneById(
+		sessionId,
+		windowId,
+		paneId
+	)
+	if session ~= nil and window ~= nil then
+		-- even if the target pane couldn't be found anymore, it makes sense to
+		-- restore session and window as that makes selecting that pane easier as
+		-- defaults will be set
+		self.session = session
+		self.window = window
+		self.pane = pane
+	end
+end
+
+-- -----------------
 -- Tests
 -- -----------------
 if utils.isMain() then
-	M:selectTarget()
+	M:selectTarget(function()
+		print(M.session.id .. ":" .. M.window.id .. ":" .. M.pane.id)
+	end)
 end
 
 return M

--- a/lua/tmuxrun/sessions.lua
+++ b/lua/tmuxrun/sessions.lua
@@ -148,6 +148,21 @@ function M.getPaneInWindowById(self, window, paneId)
 	end
 end
 
+function M.getSessionWindowPaneById(self, sessionId, windowId, paneId)
+	local session = self:getSessionById(sessionId)
+	if session == nil then
+		return nil, nil, nil
+	end
+
+	local window = session.windows[windowId]
+	if window == nil then
+		return session, nil, nil
+	end
+
+	local pane = self:getPaneInWindowById(window, paneId)
+	return session, window, pane
+end
+
 -- -----------------
 -- Clients
 -- -----------------


### PR DESCRIPTION
Selected targets will now be saved right after they are selected.
Commands are also saved right when they changed from the previous command.

All this is configurable, but turned on by default.
